### PR TITLE
Add missing ros dependency

### DIFF
--- a/turtlebot3_explore/package.xml
+++ b/turtlebot3_explore/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>turtlebot3_teleop</exec_depend>
   <exec_depend>turtlebot3_gazebo</exec_depend>
   <exec_depend>turtlebot3_slam</exec_depend>
+  <exec_depend>turtlebot3_navigation</exec_depend>
   <exec_depend>amcl</exec_depend>
 
 </package>


### PR DESCRIPTION
Following  ros package is missed to run navigation in gazebo: `turtlebot_naviagtion`.